### PR TITLE
counting up from 0 instead of counting down, make use of value return from incrby

### DIFF
--- a/server/core/views.py
+++ b/server/core/views.py
@@ -24,13 +24,10 @@ period = timedelta(seconds=10)
 
 
 def request_is_limited(red: Redis, redis_key: str, redis_limit: int, redis_period: timedelta):
-    if red.setnx(redis_key, redis_limit):
+    if red.setnx(redis_key, 0):
         red.expire(redis_key, int(redis_period.total_seconds()))
-    bucket_val = red.get(redis_key)
-    if bucket_val and int(bucket_val) > 0:
-        red.decrby(redis_key, 1)
-        return False
-    return True
+    bucket_val = red.incrby(redis_key, 1)
+    return bucket_val and int(bucket_val) > redis_limit
 
 
 class GetPongView(View):


### PR DESCRIPTION
The benefits are:

* By making use of the return value of `incrby`, the server can count requests correctly even when multiple servers are used. (Fix #6)
* By counting from 0. instead of counting down from the limit, if the limit value is changed during a time period (modified and restarted server), the server is able to act with the new limit immediately without resetting redis or waiting for the existing period to expire.
