### PR TITLE
replace the now removed django `url` with `re_path`

### DIFF
--- a/server/configuration/urls.py
+++ b/server/configuration/urls.py
@@ -14,14 +14,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import url
 from django.contrib import admin
-from django.urls import path, include
+from django.urls import path, include, re_path
 from django.views.static import serve
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('core.urls')),
-    url(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT})
+    re_path(r'^static/(?P<path>.*)$', serve, {'document_root': settings.STATIC_ROOT})
 ]
 

--- a/server/core/urls.py
+++ b/server/core/urls.py
@@ -1,5 +1,4 @@
-from django.urls import path
-from django.conf.urls import url
+from django.urls import path, re_path
 from django.views.generic import RedirectView
 
 from . import views
@@ -7,5 +6,5 @@ from . import views
 urlpatterns = [
   path('api/ping/', views.GetPongView.as_view()),
   path('', views.index, name='index'),
-  url(r'^favicon\.ico$', RedirectView.as_view(url='/static/favicon.ico')),
+  re_path(r'^favicon\.ico$', RedirectView.as_view(url='/static/favicon.ico')),
 ]


### PR DESCRIPTION
I can't run the server without this change.

> django.conf.urls.url() was deprecated in Django 3.0, and is removed in Django 4.0+

according to https://stackoverflow.com/a/70319607/267998

My venv:
```
$ pip3 freeze
asgiref==3.5.2
async-timeout==4.0.2
attrs==21.4.0
backports.zoneinfo==0.2.1
click==8.1.3
Deprecated==1.2.13
Django==4.0.5
django-cors-headers==3.13.0
django-ipware==4.0.2
django-redis==5.2.0
h11==0.13.0
iniconfig==1.1.1
packaging==21.3
pluggy==1.0.0
py==1.11.0
pyparsing==3.0.9
pytest==7.1.2
python-dotenv==0.20.0
pytz==2022.1
redis==4.3.4
rfc3986==2.0.0
sniffio==1.2.0
sqlparse==0.4.2
tomli==2.0.1
urllib3==1.26.9
uvicorn==0.18.2
uvloop==0.16.0
wrapt==1.14.1
```